### PR TITLE
remove re,rem,and baresip version from makefile

### DIFF
--- a/mk/contrib.mk
+++ b/mk/contrib.mk
@@ -11,9 +11,9 @@
 
 SOURCE_PATH	:= $(shell pwd)
 
-LIBRE_PATH	:= $(SOURCE_PATH)/re-0.4.7
-LIBREM_PATH	:= $(SOURCE_PATH)/rem-0.4.6
-BARESIP_PATH	:= $(SOURCE_PATH)/baresip-0.4.10
+LIBRE_PATH	:= $(SOURCE_PATH)/re
+LIBREM_PATH	:= $(SOURCE_PATH)/rem
+BARESIP_PATH	:= $(SOURCE_PATH)/baresip
 
 
 #


### PR DESCRIPTION
So we dont' need to edit makefile when we change version.

There is also no version in baresip-android.
