### PR TITLE
xcframeworks + ios-x86_64-simulator (m1 mac)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ include mk/contrib.mk
 all:	contrib
 
 
+xcframework:
+	@./build-xcframework.sh
+
 clean:
 	@rm -rf $(BUILD_DIR) $(CONTRIB_DIR) \
 	@rm -rf baresip rem re

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ $ make xcframework
 
 ## Install
 - Link XCode target with:
-    - `contrib/fat/lib/libbaresip.a`, `contrib/fat/lib/libre.a`, `contrib/fat/lib/librem.a`  
+    - `contrib/xcframework/libbaresip.a.xcframework`, `contrib/xcframework/libre.a.xcframework`, `contrib/xcframework/librem.a.xcframework`  
     - `libresolv.9.dlyb`
     - `AVFoundation`, `SystemConfiguration`, `CFNetwork`, `CoreMedia`, `AudioToolbox`, `CoreVideo` frameworks
-- Setup build settings:
-    - header search path with:
-        - `baresip/include`
-        - `re/include`
-        - `rem/include`
-    - library search path with:
-        - `contrib/fat/lib`
+
+- Add to bridging headers
+```
+#import "re.h"
+#import "rem.h"
+#import "baresip.h"
+```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To build static libraries for iOS run the following command:
 ```shell
 $ make download
 $ make contrib
+$ make xcframework
 ```
 
 ## Install

--- a/build-xcframework.sh
+++ b/build-xcframework.sh
@@ -6,6 +6,10 @@ LIBBARESIP="libbaresip.a"
 LIBRE="libre.a"
 LIBREM="librem.a"
 
+LIBBARESIP_HEADERS="baresip/include"
+LIBRE_HEADERS="re/include"
+LIBREM_HEADERS="rem/include"
+
 IPHONEOS="contrib/iphonesimulator"
 IPHONESIMULATOR="contrib/iphoneos"
 XCFRAMEWORK="contrib/xcframework"
@@ -36,18 +40,18 @@ IOS_ARM_SIM_LIBRE="contrib/slim/lib/libre.a"
 IOS_ARM_SIM_LIBREM="contrib/slim/lib/librem.a"
 
 xcodebuild -create-xcframework \
--library ./$IPHONEOS/$LIBBARESIP \
--library ./$IPHONESIMULATOR/$LIBBARESIP \
+-library ./$IPHONEOS/$LIBBARESIP -headers ./$LIBBARESIP_HEADERS \
+-library ./$IPHONESIMULATOR/$LIBBARESIP -headers ./$LIBBARESIP_HEADERS \
 -output "$XCFRAMEWORK/$LIBBARESIP.xcframework"
 
 xcodebuild -create-xcframework \
--library ./$IPHONEOS/$LIBRE \
--library ./$IPHONESIMULATOR/$LIBRE \
+-library ./$IPHONEOS/$LIBRE -headers ./$LIBRE_HEADERS \
+-library ./$IPHONESIMULATOR/$LIBRE -headers ./$LIBRE_HEADERS \
 -output "$XCFRAMEWORK/$LIBRE.xcframework"
 
 xcodebuild -create-xcframework \
--library ./$IPHONEOS/$LIBREM \
--library ./$IPHONESIMULATOR/$LIBREM \
+-library ./$IPHONEOS/$LIBREM -headers ./$LIBREM_HEADERS \
+-library ./$IPHONESIMULATOR/$LIBREM -headers ./$LIBREM_HEADERS \
 -output "$XCFRAMEWORK/$LIBREM.xcframework"
 
 lipo $XCFRAMEWORK/$LIBBARESIP.xcframework/ios-x86_64-simulator/libbaresip.a $IOS_ARM_SIM_LIBBARESIP -create -output $XCFRAMEWORK/$LIBBARESIP.xcframework/ios-x86_64-simulator/libbaresip.a

--- a/build-xcframework.sh
+++ b/build-xcframework.sh
@@ -28,6 +28,26 @@ xcrun lipo -remove arm64 -remove armv7 -remove armv7s $FAT_PATH/$LIBBARESIP -o .
 xcrun lipo -remove arm64 -remove armv7 -remove armv7s $FAT_PATH/$LIBRE -o ./$IPHONESIMULATOR/$LIBRE
 xcrun lipo -remove arm64 -remove armv7 -remove armv7s $FAT_PATH/$LIBREM -o ./$IPHONESIMULATOR/$LIBREM
 
-xcodebuild -create-xcframework -library ./$IPHONEOS/$LIBBARESIP -library ./$IPHONESIMULATOR/$LIBBARESIP -output "$XCFRAMEWORK/$LIBBARESIP.xcframework"
-xcodebuild -create-xcframework -library ./$IPHONEOS/$LIBRE -library ./$IPHONESIMULATOR/$LIBRE -output "$XCFRAMEWORK/$LIBRE.xcframework"
-xcodebuild -create-xcframework -library ./$IPHONEOS/$LIBREM -library ./$IPHONESIMULATOR/$LIBREM -output "$XCFRAMEWORK/$LIBREM.xcframework"
+# m1 arm simulator
+IOS_ARM_SIM_LIBBARESIP="contrib/slim/lib/libbaresip.a"
+IOS_ARM_SIM_LIBRE="contrib/slim/lib/libre.a"
+IOS_ARM_SIM_LIBREM="contrib/slim/lib/librem.a"
+
+xcodebuild -create-xcframework \
+-library ./$IPHONEOS/$LIBBARESIP \
+-library ./$IPHONESIMULATOR/$LIBBARESIP \
+-output "$XCFRAMEWORK/$LIBBARESIP.xcframework"
+
+xcodebuild -create-xcframework \
+-library ./$IPHONEOS/$LIBRE \
+-library ./$IPHONESIMULATOR/$LIBRE \
+-output "$XCFRAMEWORK/$LIBRE.xcframework"
+
+xcodebuild -create-xcframework \
+-library ./$IPHONEOS/$LIBREM \
+-library ./$IPHONESIMULATOR/$LIBREM \
+-output "$XCFRAMEWORK/$LIBREM.xcframework"
+
+lipo $XCFRAMEWORK/$LIBBARESIP.xcframework/ios-x86_64-simulator/libbaresip.a $IOS_ARM_SIM_LIBBARESIP -create -output $XCFRAMEWORK/$LIBBARESIP.xcframework/ios-x86_64-simulator/libbaresip.a
+lipo $XCFRAMEWORK/$LIBRE.xcframework/ios-x86_64-simulator/libre.a $IOS_ARM_SIM_LIBRE -create -output $XCFRAMEWORK/$LIBRE.xcframework/ios-x86_64-simulator/libre.a
+lipo $XCFRAMEWORK/$LIBREM.xcframework/ios-x86_64-simulator/librem.a $IOS_ARM_SIM_LIBREM -create -output $XCFRAMEWORK/$LIBREM.xcframework/ios-x86_64-simulator/librem.a

--- a/build-xcframework.sh
+++ b/build-xcframework.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+FAT_PATH="contrib/fat/lib"
+
+LIBBARESIP="libbaresip.a"
+LIBRE="libre.a"
+LIBREM="librem.a"
+
+IPHONEOS="contrib/iphonesimulator"
+IPHONESIMULATOR="contrib/iphoneos"
+XCFRAMEWORK="contrib/xcframework"
+
+mkdir -p $IPHONEOS
+mkdir -p $IPHONESIMULATOR
+mkdir -p $XCFRAMEWORK
+
+test -f "$FAT_PATH/$LIBBARESIP" && echo "$LIBBARESIP exists."
+test -f "$FAT_PATH/$LIBRE" && echo "$LIBRE exists."
+test -f "$FAT_PATH/$LIBREM" && echo "$LIBREM exists."
+
+# device
+xcrun lipo -remove x86_64 -remove armv7 -remove armv7s $FAT_PATH/$LIBBARESIP -o ./$IPHONEOS/$LIBBARESIP
+xcrun lipo -remove x86_64 -remove armv7 -remove armv7s $FAT_PATH/$LIBRE -o ./$IPHONEOS/$LIBRE
+xcrun lipo -remove x86_64 -remove armv7 -remove armv7s $FAT_PATH/$LIBREM -o ./$IPHONEOS/$LIBREM
+
+# simulator
+xcrun lipo -remove arm64 -remove armv7 -remove armv7s $FAT_PATH/$LIBBARESIP -o ./$IPHONESIMULATOR/$LIBBARESIP
+xcrun lipo -remove arm64 -remove armv7 -remove armv7s $FAT_PATH/$LIBRE -o ./$IPHONESIMULATOR/$LIBRE
+xcrun lipo -remove arm64 -remove armv7 -remove armv7s $FAT_PATH/$LIBREM -o ./$IPHONESIMULATOR/$LIBREM
+
+xcodebuild -create-xcframework -library ./$IPHONEOS/$LIBBARESIP -library ./$IPHONESIMULATOR/$LIBBARESIP -output "$XCFRAMEWORK/$LIBBARESIP.xcframework"
+xcodebuild -create-xcframework -library ./$IPHONEOS/$LIBRE -library ./$IPHONESIMULATOR/$LIBRE -output "$XCFRAMEWORK/$LIBRE.xcframework"
+xcodebuild -create-xcframework -library ./$IPHONEOS/$LIBREM -library ./$IPHONESIMULATOR/$LIBREM -output "$XCFRAMEWORK/$LIBREM.xcframework"

--- a/build-xcframework.sh
+++ b/build-xcframework.sh
@@ -29,6 +29,8 @@ xcrun lipo -remove arm64 -remove armv7 -remove armv7s $FAT_PATH/$LIBRE -o ./$IPH
 xcrun lipo -remove arm64 -remove armv7 -remove armv7s $FAT_PATH/$LIBREM -o ./$IPHONESIMULATOR/$LIBREM
 
 # m1 arm simulator
+# https://developer.apple.com/forums/thread/66633
+
 IOS_ARM_SIM_LIBBARESIP="contrib/slim/lib/libbaresip.a"
 IOS_ARM_SIM_LIBRE="contrib/slim/lib/libre.a"
 IOS_ARM_SIM_LIBREM="contrib/slim/lib/librem.a"


### PR DESCRIPTION
Build the library to the new XCFramework format and  can use M1 simulator now without running Xcode under Rosetta. 